### PR TITLE
3in7

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ npm install -S epaperjs
 | ------------------------------------------------------------------ | ---------------------- |
 | [Waveshare 4.2"](https://www.waveshare.com/4.2inch-e-Paper.htm)    | Black / White, 4 Gray  |
 | [Waveshare 7.5" v2](https://www.waveshare.com/7.5inch-e-Paper.htm) | Black / White          |
+| [Waveshare 3.7" hat](https://www.waveshare.com/3.7inch-e-paper-hat.htm) | Black / White, 4 Gray  |
 
 ### Adding Support For Additional Displays
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -43,6 +43,28 @@
                 "-lwiringPi",
                 "-lm"
             ]
+        },
+        {
+            "target_name": "waveshare3in7",
+            "cflags!": [ "-fno-exceptions" ],
+            "cflags_cc!": [ "-fno-exceptions" ],
+            "sources": [ 
+                "./c/EPD_3in7_node.cc",
+                "./c/DEV_Config.c",
+                "./c/EPD_3in7.c"
+            ],
+            "defines": [
+                "RPI",
+                "USE_WIRINGPI_LIB",
+                "NAPI_DISABLE_CPP_EXCEPTIONS"
+            ],
+            "include_dirs": [
+                "<!@(node -p \"require('node-addon-api').include\")"
+            ],
+            "libraries": [
+                "-lwiringPi",
+                "-lm"
+            ]
         }
     ]
 }

--- a/c/EPD_3in7.c
+++ b/c/EPD_3in7.c
@@ -1,0 +1,598 @@
+/*****************************************************************************
+* | File      	:   EPD_3IN7.C
+* | Author      :   Waveshare team
+* | Function    :   3.7inch e-paper
+* | Info        :
+*----------------
+* |	This version:   V1.0
+* | Date        :   2020-07-16
+* | Info        :
+* -----------------------------------------------------------------------------
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+******************************************************************************/
+#include "EPD_3in7.h"
+#include "Debug.h"
+
+static const UBYTE lut_4Gray_GC[] =
+{
+0x2A,0x06,0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//1
+0x28,0x06,0x14,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//2
+0x20,0x06,0x10,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//3
+0x14,0x06,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//4
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//5
+0x00,0x02,0x02,0x0A,0x00,0x00,0x00,0x08,0x08,0x02,//6
+0x00,0x02,0x02,0x0A,0x00,0x00,0x00,0x00,0x00,0x00,//7
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//8
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//9
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//10
+0x22,0x22,0x22,0x22,0x22
+};	
+
+static const UBYTE lut_1Gray_GC[] =
+{
+0x2A,0x05,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//1
+0x05,0x2A,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//2
+0x2A,0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//3
+0x05,0x0A,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//4
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//5
+0x00,0x02,0x03,0x0A,0x00,0x02,0x06,0x0A,0x05,0x00,//6
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//7
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//8
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//9
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//10
+0x22,0x22,0x22,0x22,0x22
+};  
+
+static const UBYTE lut_1Gray_DU[] =
+{
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//1
+0x01,0x2A,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+0x0A,0x55,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//3
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//5
+0x00,0x00,0x05,0x05,0x00,0x05,0x03,0x05,0x05,0x00,
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//7
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,//9
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+0x22,0x22,0x22,0x22,0x22
+}; 
+
+static const UBYTE lut_1Gray_A2[] =
+{
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //1
+0x0A,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //2
+0x05,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //3
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //4
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //5
+0x00,0x00,0x03,0x05,0x00,0x00,0x00,0x00,0x00,0x00, //6
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //7
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //8
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //9
+0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //10
+0x22,0x22,0x22,0x22,0x22
+}; 
+
+/******************************************************************************
+function :	Software reset
+parameter:
+******************************************************************************/
+static void EPD_3IN7_Reset(void)
+{
+    DEV_Digital_Write(EPD_RST_PIN, 1);
+    DEV_Delay_ms(30);
+    DEV_Digital_Write(EPD_RST_PIN, 0);
+    DEV_Delay_ms(3);
+    DEV_Digital_Write(EPD_RST_PIN, 1);
+    DEV_Delay_ms(30);
+}
+
+/******************************************************************************
+function :	send command
+parameter:
+     Reg : Command register
+******************************************************************************/
+static void EPD_3IN7_SendCommand(UBYTE Reg)
+{
+    DEV_Digital_Write(EPD_DC_PIN, 0);
+    DEV_Digital_Write(EPD_CS_PIN, 0);
+    DEV_SPI_WriteByte(Reg);
+    DEV_Digital_Write(EPD_CS_PIN, 1);
+}
+
+/******************************************************************************
+function :	send data
+parameter:
+    Data : Write data
+******************************************************************************/
+static void EPD_3IN7_SendData(UBYTE Data)
+{
+    DEV_Digital_Write(EPD_DC_PIN, 1);
+    DEV_Digital_Write(EPD_CS_PIN, 0);
+    DEV_SPI_WriteByte(Data);
+    DEV_Digital_Write(EPD_CS_PIN, 1);
+}
+
+static void EPD_3IN7_ReadBusy_HIGH(void)
+{
+    Debug("e-Paper busy\r\n");
+    UBYTE busy;
+    do {
+        busy = DEV_Digital_Read(EPD_BUSY_PIN);
+    } while(busy);
+    DEV_Delay_ms(200);
+    Debug("e-Paper busy release\r\n");
+}
+
+/******************************************************************************
+function :	set the look-up tables
+parameter:
+******************************************************************************/
+void EPD_3IN7_Load_LUT(UBYTE lut)
+{
+  UWORD i;
+  EPD_3IN7_SendCommand(0x32);
+  for (i = 0; i < 105; i++)
+  {
+    if(lut == 0)
+        EPD_3IN7_SendData(lut_4Gray_GC[i]);
+    else if(lut == 1)
+        EPD_3IN7_SendData(lut_1Gray_GC[i]);
+    else if(lut == 2)
+        EPD_3IN7_SendData(lut_1Gray_DU[i]);
+    else if(lut == 3)
+        EPD_3IN7_SendData(lut_1Gray_A2[i]);  
+    else
+        Debug("There is no such lut \r\n");
+  }
+}
+
+/******************************************************************************
+function :	Initialize the e-Paper register
+parameter:
+******************************************************************************/
+void EPD_3IN7_4Gray_Init(void)
+{
+    EPD_3IN7_Reset();
+    
+    EPD_3IN7_SendCommand(0x12);
+    DEV_Delay_ms(300);
+    
+    EPD_3IN7_SendCommand(0x46); 
+    EPD_3IN7_SendData(0xF7);
+    EPD_3IN7_ReadBusy_HIGH();
+    EPD_3IN7_SendCommand(0x47);
+    EPD_3IN7_SendData(0xF7);
+    EPD_3IN7_ReadBusy_HIGH(); 
+    
+    EPD_3IN7_SendCommand(0x01); // setting gaet number
+    EPD_3IN7_SendData(0xDF);
+    EPD_3IN7_SendData(0x01);
+    EPD_3IN7_SendData(0x00);
+
+    EPD_3IN7_SendCommand(0x03); // set gate voltage
+    EPD_3IN7_SendData(0x00);
+
+    EPD_3IN7_SendCommand(0x04); // set source voltage
+    EPD_3IN7_SendData(0x41);
+    EPD_3IN7_SendData(0xA8);
+    EPD_3IN7_SendData(0x32);
+
+    EPD_3IN7_SendCommand(0x11); // set data entry sequence
+    EPD_3IN7_SendData(0x03);
+
+    EPD_3IN7_SendCommand(0x3C); // set border 
+    EPD_3IN7_SendData(0x03);
+
+    EPD_3IN7_SendCommand(0x0C); // set booster strength
+    EPD_3IN7_SendData(0xAE);
+    EPD_3IN7_SendData(0xC7);
+    EPD_3IN7_SendData(0xC3);
+    EPD_3IN7_SendData(0xC0);
+    EPD_3IN7_SendData(0xC0);  
+
+    EPD_3IN7_SendCommand(0x18); // set internal sensor on
+    EPD_3IN7_SendData(0x80);
+     
+    EPD_3IN7_SendCommand(0x2C); // set vcom value
+    EPD_3IN7_SendData(0x44);
+
+    EPD_3IN7_SendCommand(0x37); // set display option, these setting turn on previous function
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);  
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);  
+
+    EPD_3IN7_SendCommand(0x44); // setting X direction start/end position of RAM
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x17);
+    EPD_3IN7_SendData(0x01);
+
+    EPD_3IN7_SendCommand(0x45); // setting Y direction start/end position of RAM
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0xDF);
+    EPD_3IN7_SendData(0x01);
+
+    EPD_3IN7_SendCommand(0x22); // Display Update Control 2
+    EPD_3IN7_SendData(0xCF);
+}
+
+/******************************************************************************
+function :  Initialize the e-Paper register
+parameter:
+******************************************************************************/
+void EPD_3IN7_1Gray_Init(void)
+{
+    EPD_3IN7_Reset();
+    
+    EPD_3IN7_SendCommand(0x12);
+    DEV_Delay_ms(300);
+    
+    EPD_3IN7_SendCommand(0x46); 
+    EPD_3IN7_SendData(0xF7);
+    EPD_3IN7_ReadBusy_HIGH();
+    EPD_3IN7_SendCommand(0x47);
+    EPD_3IN7_SendData(0xF7);
+    EPD_3IN7_ReadBusy_HIGH(); 
+
+    EPD_3IN7_SendCommand(0x01); // setting gaet number
+    EPD_3IN7_SendData(0xDF);
+    EPD_3IN7_SendData(0x01);
+    EPD_3IN7_SendData(0x00);
+
+    EPD_3IN7_SendCommand(0x03); // set gate voltage
+    EPD_3IN7_SendData(0x00);
+
+    EPD_3IN7_SendCommand(0x04); // set source voltage
+    EPD_3IN7_SendData(0x41);
+    EPD_3IN7_SendData(0xA8);
+    EPD_3IN7_SendData(0x32);
+
+    EPD_3IN7_SendCommand(0x11); // set data entry sequence
+    EPD_3IN7_SendData(0x03);
+
+    EPD_3IN7_SendCommand(0x3C); // set border 
+    EPD_3IN7_SendData(0x03);
+
+    EPD_3IN7_SendCommand(0x0C); // set booster strength
+    EPD_3IN7_SendData(0xAE);
+    EPD_3IN7_SendData(0xC7);
+    EPD_3IN7_SendData(0xC3);
+    EPD_3IN7_SendData(0xC0);
+    EPD_3IN7_SendData(0xC0);  
+
+    EPD_3IN7_SendCommand(0x18); // set internal sensor on
+    EPD_3IN7_SendData(0x80);
+     
+    EPD_3IN7_SendCommand(0x2C); // set vcom value
+    EPD_3IN7_SendData(0x44);
+	
+    EPD_3IN7_SendCommand(0x37); // set display option, these setting turn on previous function
+    EPD_3IN7_SendData(0x00);     //can switch 1 gray or 4 gray
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);  
+    EPD_3IN7_SendData(0x4F);
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);
+    EPD_3IN7_SendData(0xFF);  
+
+    EPD_3IN7_SendCommand(0x44); // setting X direction start/end position of RAM
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x17);
+    EPD_3IN7_SendData(0x01);
+
+    EPD_3IN7_SendCommand(0x45); // setting Y direction start/end position of RAM
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0xDF);
+    EPD_3IN7_SendData(0x01);
+
+    EPD_3IN7_SendCommand(0x22); // Display Update Control 2
+    EPD_3IN7_SendData(0xCF);
+}
+
+/******************************************************************************
+function :	Clear screen
+parameter:
+******************************************************************************/
+void EPD_3IN7_4Gray_Clear(void)
+{
+    UWORD Width, Height;
+    Width = (EPD_3IN7_WIDTH % 8 == 0)? (EPD_3IN7_WIDTH / 8 ): (EPD_3IN7_WIDTH / 8 + 1);
+    Height = EPD_3IN7_HEIGHT;
+
+    EPD_3IN7_SendCommand(0x49);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendCommand(0x4E);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendCommand(0x4F);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    
+    EPD_3IN7_SendCommand(0x24);
+    for (UWORD j = 0; j < Height; j++) {
+       for (UWORD i = 0; i < Width; i++) {
+           EPD_3IN7_SendData(0xff);
+       }
+    }
+    
+    EPD_3IN7_SendCommand(0x4E);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+     
+    EPD_3IN7_SendCommand(0x4F);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    
+    EPD_3IN7_SendCommand(0x26);
+    for (UWORD j = 0; j < Height; j++) {
+       for (UWORD i = 0; i < Width; i++) {
+           EPD_3IN7_SendData(0xff);
+       }
+    }
+      
+    EPD_3IN7_Load_LUT(0);
+    EPD_3IN7_SendCommand(0x22);
+    EPD_3IN7_SendData(0xC7);
+
+    EPD_3IN7_SendCommand(0x20);
+    EPD_3IN7_ReadBusy_HIGH();     
+}
+
+/******************************************************************************
+function :  Clear screen
+parameter:
+******************************************************************************/
+void EPD_3IN7_1Gray_Clear(void)
+{
+  UWORD i;
+  UWORD IMAGE_COUNTER = EPD_3IN7_WIDTH * EPD_3IN7_HEIGHT / 8;
+
+  EPD_3IN7_SendCommand(0x4E);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendCommand(0x4F);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendData(0x00);
+
+  EPD_3IN7_SendCommand(0x24);
+  for (i = 0; i < IMAGE_COUNTER; i++)
+  {
+    EPD_3IN7_SendData(0xff);
+  }
+  
+  EPD_3IN7_Load_LUT(2);
+  
+  EPD_3IN7_SendCommand(0x20);
+  EPD_3IN7_ReadBusy_HIGH();    
+}
+
+/******************************************************************************
+function :	Sends the image buffer in RAM to e-Paper and displays
+parameter:
+******************************************************************************/
+void EPD_3IN7_4Gray_Display(const UBYTE *Image)
+{
+    UDOUBLE i,j,k;
+    UBYTE temp1,temp2,temp3;
+    
+    EPD_3IN7_SendCommand(0x49);
+    EPD_3IN7_SendData(0x00);
+
+    
+    EPD_3IN7_SendCommand(0x4E);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    
+    
+    EPD_3IN7_SendCommand(0x4F);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    
+    EPD_3IN7_SendCommand(0x24);
+    for(i=0;i<16800;i++){
+        temp3=0;
+        for(j=0; j<2; j++) {
+            temp1 = Image[i*2+j];
+            for(k=0; k<2; k++) {
+                temp2 = temp1&0xC0;
+                if(temp2 == 0xC0)
+                    temp3 |= 0x01;//white
+                else if(temp2 == 0x00)
+                    temp3 |= 0x00;  //black
+                else if(temp2 == 0x80)
+                    temp3 |= 0x00;  //gray1
+                else //0x40
+                    temp3 |= 0x01; //gray2
+                temp3 <<= 1;
+
+                temp1 <<= 2;
+                temp2 = temp1&0xC0 ;
+                if(temp2 == 0xC0)  //white
+                    temp3 |= 0x01;
+                else if(temp2 == 0x00) //black
+                    temp3 |= 0x00;
+                else if(temp2 == 0x80)
+                    temp3 |= 0x00; //gray1
+                else    //0x40
+                    temp3 |= 0x01;	//gray2
+                if(j!=1 || k!=1)
+                    temp3 <<= 1;
+
+                temp1 <<= 2;
+            }
+
+        }
+        EPD_3IN7_SendData(temp3);
+    }
+    // new  data
+    EPD_3IN7_SendCommand(0x4E);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+     
+    
+    EPD_3IN7_SendCommand(0x4F);
+    EPD_3IN7_SendData(0x00);
+    EPD_3IN7_SendData(0x00);
+    
+    EPD_3IN7_SendCommand(0x26);
+    for(i=0; i<16800; i++) {
+        temp3=0;
+        for(j=0; j<2; j++) {
+            temp1 = Image[i*2+j];
+            for(k=0; k<2; k++) {
+                temp2 = temp1&0xC0 ;
+                if(temp2 == 0xC0)
+                    temp3 |= 0x01;//white
+                else if(temp2 == 0x00)
+                    temp3 |= 0x00;  //black
+                else if(temp2 == 0x80)
+                    temp3 |= 0x01;  //gray1
+                else //0x40
+                    temp3 |= 0x00; //gray2
+                temp3 <<= 1;
+
+                temp1 <<= 2;
+                temp2 = temp1&0xC0 ;
+                if(temp2 == 0xC0)  //white
+                    temp3 |= 0x01;
+                else if(temp2 == 0x00) //black
+                    temp3 |= 0x00;
+                else if(temp2 == 0x80)
+                    temp3 |= 0x01; //gray1
+                else    //0x40
+                    temp3 |= 0x00;	//gray2
+                if(j!=1 || k!=1)
+                    temp3 <<= 1;
+
+                temp1 <<= 2;
+            }
+        }
+        EPD_3IN7_SendData(temp3);
+    }
+
+    EPD_3IN7_Load_LUT(0);
+    
+    EPD_3IN7_SendCommand(0x22);
+    EPD_3IN7_SendData(0xC7);
+    
+    EPD_3IN7_SendCommand(0x20);
+    
+    EPD_3IN7_ReadBusy_HIGH(); 
+}
+
+/******************************************************************************
+function :  Sends the image buffer in RAM to e-Paper and displays
+parameter:
+******************************************************************************/
+void EPD_3IN7_1Gray_Display(const UBYTE *Image)
+{
+  UWORD i;
+  UWORD IMAGE_COUNTER = EPD_3IN7_WIDTH * EPD_3IN7_HEIGHT / 8;
+
+  EPD_3IN7_SendCommand(0x4E);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendCommand(0x4F);
+  EPD_3IN7_SendData(0x00);
+  EPD_3IN7_SendData(0x00);
+
+  EPD_3IN7_SendCommand(0x24);
+  for (i = 0; i < IMAGE_COUNTER; i++)
+  {
+    EPD_3IN7_SendData(Image[i]);
+  }
+
+  EPD_3IN7_Load_LUT(2);
+  EPD_3IN7_SendCommand(0x20);
+  EPD_3IN7_ReadBusy_HIGH();  
+}
+
+/******************************************************************************
+function :  Sends part the image buffer in RAM to e-Paper and displays
+notes:
+    You can send a part of data to e-Paper,But this function is not recommended
+    1.Xsize must be as big as EPD_3IN7_WIDTH
+    2.Ypointer must be start at 0
+******************************************************************************/
+void EPD_3IN7_1Gray_Display_Part(const UBYTE *Image, UWORD Xstart, UWORD Ystart, UWORD Xend, UWORD Yend)
+{
+	UWORD i, Width;
+	Width = (Xend-Xstart)%8 == 0 ? (Xend-Xstart)/8 : (Xend-Xstart)/8+1;
+	UWORD IMAGE_COUNTER = Width * (Yend-Ystart);
+
+	Xend -= 1;
+	Yend -= 1;
+
+	EPD_3IN7_SendCommand(0x44);
+	EPD_3IN7_SendData(Xstart & 0xff);
+	EPD_3IN7_SendData((Xstart>>8) & 0x03);
+	EPD_3IN7_SendData(Xend & 0xff);
+	EPD_3IN7_SendData((Xend>>8) & 0x03);
+	EPD_3IN7_SendCommand(0x45);
+	EPD_3IN7_SendData(Ystart & 0xff);
+	EPD_3IN7_SendData((Ystart>>8) & 0x03);
+	EPD_3IN7_SendData(Yend & 0xff);
+	EPD_3IN7_SendData((Yend>>8) & 0x03);
+
+    EPD_3IN7_SendCommand(0x4E); // SET_RAM_X_ADDRESS_COUNTER
+    EPD_3IN7_SendData(Xstart & 0xFF);
+
+    EPD_3IN7_SendCommand(0x4F); // SET_RAM_Y_ADDRESS_COUNTER
+    EPD_3IN7_SendData(Ystart & 0xFF);
+    EPD_3IN7_SendData((Ystart >> 8) & 0xFF);
+	
+	EPD_3IN7_SendCommand(0x24);
+	for (i = 0; i < IMAGE_COUNTER; i++)
+	{
+	EPD_3IN7_SendData(Image[i]);
+	}
+
+	EPD_3IN7_Load_LUT(3);
+	EPD_3IN7_SendCommand(0x20);
+	EPD_3IN7_ReadBusy_HIGH();    
+}
+
+/******************************************************************************
+function :	Enter sleep mode
+parameter:
+******************************************************************************/
+void EPD_3IN7_Sleep(void)
+{
+    EPD_3IN7_SendCommand(0X50);
+    EPD_3IN7_SendData(0xf7);
+    EPD_3IN7_SendCommand(0X02);  	//power off
+    EPD_3IN7_SendCommand(0X07);  	//deep sleep
+    EPD_3IN7_SendData(0xA5);
+}

--- a/c/EPD_3in7.h
+++ b/c/EPD_3in7.h
@@ -1,0 +1,51 @@
+/*****************************************************************************
+* | File      	:   EPD_3IN7.h
+* | Author      :   Waveshare team
+* | Function    :   3.7inch e-paper
+* | Info        :
+*----------------
+* |	This version:   V1.0
+* | Date        :   2020-07-16
+* | Info        :
+* -----------------------------------------------------------------------------
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+******************************************************************************/
+#ifndef __EPD_3IN7_H_
+#define __EPD_3IN7_H_
+
+#include "DEV_Config.h"
+
+// Display resolution
+#define EPD_3IN7_WIDTH       280
+#define EPD_3IN7_HEIGHT      480 
+
+void EPD_3IN7_4Gray_Clear(void);
+void EPD_3IN7_4Gray_Init(void);
+void EPD_3IN7_4Gray_Display(const UBYTE *Image);
+
+void EPD_3IN7_1Gray_Clear(void);
+void EPD_3IN7_1Gray_Init(void);
+void EPD_3IN7_1Gray_Display(const UBYTE *Image);
+void EPD_3IN7_1Gray_Display_Part(const UBYTE *Image, UWORD Xstart, UWORD Ystart, UWORD Xend, UWORD Yend);
+
+void EPD_3IN7_Sleep(void);
+
+#endif

--- a/c/EPD_3in7_node.cc
+++ b/c/EPD_3in7_node.cc
@@ -12,7 +12,10 @@ Napi::Number DEV_Init(const Napi::CallbackInfo& info) {
 
 Napi::Value Init(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    //if previously used in 4gray mode I think it must be cleared with 4gray clear before it can be used in 1gray mode. This will clear it on initialization of 1 gray mode.
+    /*
+    if previously used in 4gray mode a residual image remains after init/clear/display in 1 Gray mode. 
+    This will init as 4gray and clear it before init as 1gray mode ensuring a clear screen when entering 1 gray mode.
+    */
     EPD_3IN7_4Gray_Init();
     EPD_3IN7_4Gray_Clear();
     EPD_3IN7_1Gray_Init();
@@ -25,7 +28,6 @@ Napi::Value Init_4Gray(const Napi::CallbackInfo& info) {
     return env.Undefined();
 }
 
-//Calling display() in 1gray mode after previously diaplaying a 4gray image will not ovewrite the entire display. 
 Napi::Value Display(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     Napi::Buffer<uint8_t> jsBuffer = info[0].As<Napi::Buffer<uint8_t>>();

--- a/c/EPD_3in7_node.cc
+++ b/c/EPD_3in7_node.cc
@@ -1,0 +1,82 @@
+#include "napi.h"
+extern "C" {
+    #include "DEV_Config.h"
+    #include "EPD_3in7.h"
+}
+
+Napi::Number DEV_Init(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    uint8_t result = DEV_Module_Init();
+    return Napi::Number::New(env, result);
+}
+
+Napi::Value Init(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    //if previously used in 4gray mode I think it must be cleared with 4gray clear before it can be used in 1gray mode. This will clear it on initialization of 1 gray mode.
+    EPD_3IN7_4Gray_Init();
+    EPD_3IN7_4Gray_Clear();
+    EPD_3IN7_1Gray_Init();
+    return env.Undefined();
+}
+
+Napi::Value Init_4Gray(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    EPD_3IN7_4Gray_Init();
+    return env.Undefined();
+}
+
+//Calling display() in 1gray mode after previously diaplaying a 4gray image will not ovewrite the entire display. 
+Napi::Value Display(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::Buffer<uint8_t> jsBuffer = info[0].As<Napi::Buffer<uint8_t>>();
+    EPD_3IN7_1Gray_Display(reinterpret_cast<uint8_t *>(jsBuffer.Data()));
+    return env.Undefined();
+}
+
+Napi::Value Display_4Gray(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::Buffer<uint8_t> jsBuffer = info[0].As<Napi::Buffer<uint8_t>>();
+    EPD_3IN7_4Gray_Display(reinterpret_cast<uint8_t *>(jsBuffer.Data()));
+    return env.Undefined();
+}
+
+Napi::Value Clear(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    EPD_3IN7_1Gray_Clear();
+    return env.Undefined();
+}
+
+Napi::Value Clear_4Gray(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    EPD_3IN7_4Gray_Clear();
+    return env.Undefined();
+}
+
+Napi::Value Sleep(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    EPD_3IN7_Sleep();
+    return env.Undefined();
+}
+
+Napi::Object SetupNapi(Napi::Env env, Napi::Object exports) {
+    exports.Set(Napi::String::New(env, "dev_init"),
+                Napi::Function::New(env, DEV_Init));
+    exports.Set(Napi::String::New(env, "init"),
+                Napi::Function::New(env, Init));
+    exports.Set(Napi::String::New(env, "init_4Gray"),
+                Napi::Function::New(env, Init_4Gray));
+    exports.Set(Napi::String::New(env, "display"),
+                Napi::Function::New(env, Display));
+    exports.Set(Napi::String::New(env, "display_4Gray"),
+                Napi::Function::New(env, Display_4Gray));
+    exports.Set(Napi::String::New(env, "clear_4Gray"),
+                Napi::Function::New(env, Clear_4Gray));
+    exports.Set(Napi::String::New(env, "clear"),
+                Napi::Function::New(env, Clear));
+    exports.Set(Napi::String::New(env, "sleep"),
+                Napi::Function::New(env, Sleep));
+
+    return exports;
+}
+
+NODE_API_MODULE(epaper, SetupNapi)

--- a/devices.js
+++ b/devices.js
@@ -1,6 +1,7 @@
 const image = require('./image.js');
 const waveshare4In2Driver = require('bindings')('waveshare4in2.node');
 const waveshare7in5v2Driver = require('bindings')('waveshare7in5v2.node');
+const waveshare3In7Driver = require('bindings')('waveshare3in7.node')
 
 const waveshare4in2Horizontal = {
     height: 300,
@@ -80,6 +81,59 @@ const waveshare7in2v2Vertical = {
     },
 };
 
+const waveshare3in7Vertical = {
+    height: 480,
+    width: 280,
+    driver: waveshare3In7Driver,
+    displayPNG: async function (imgContents) {
+        const buffer = await image.convertPNGto1BitBW(imgContents);
+        this.driver.display(buffer);
+    },
+    init: function () {
+        this.driver.init();
+    },
+};
+
+const waveshare3in7Horizontal = {
+    height: 280,
+    width: 480,
+    driver: waveshare3In7Driver,
+    displayPNG: async function (imgContents) {
+        const buffer = await image.convertPNGto1BitBWRotated(imgContents);
+        this.driver.display(buffer);
+    },
+    init: function () {
+        this.driver.init();
+    },
+};
+
+const waveshare3in7VerticalGray = {
+    height: 480,
+    width: 280,
+    driver: waveshare3In7Driver,
+    displayPNG: async function (imgContents) {
+        const buffer = await image.convertPNGto4Grey(imgContents);
+        this.driver.display_4Gray(buffer);
+    },
+    init: function () {
+        this.driver.init_4Gray();
+    },
+};
+
+const waveshare3in7HorizontalGray = {
+    height: 280,
+    width: 480,
+    driver: waveshare3In7Driver,
+    displayPNG: async function (imgContents, color_depth) {
+        const buffer = await image.convertPNGto4GreyRotated(imgContents);
+        this.driver.display_4Gray(buffer);
+    },
+    init: function () {
+        this.driver.init_4Gray();
+    },
+};
+
+
 const devices = {
     // default waveshare4in2 kept for backwards compatibility with release 1.0.0
     waveshare4in2: waveshare4in2Horizontal,
@@ -91,6 +145,12 @@ const devices = {
     waveshare7in5v2: waveshare7in5v2Horizontal,
     waveshare7in5v2Horizontal,
     waveshare7in2v2Vertical,
+    // default
+    waveshare3in7: waveshare3in7HorizontalGray,
+    waveshare3in7Horizontal,
+    waveshare3in7HorizontalGray,
+    waveshare3in7Vertical,
+    waveshare3in7VerticalGray,
 };
 
 module.exports = devices;

--- a/devices.js
+++ b/devices.js
@@ -1,7 +1,7 @@
 const image = require('./image.js');
 const waveshare4In2Driver = require('bindings')('waveshare4in2.node');
 const waveshare7in5v2Driver = require('bindings')('waveshare7in5v2.node');
-const waveshare3In7Driver = require('bindings')('waveshare3in7.node')
+const waveshare3In7Driver = require('bindings')('waveshare3in7.node');
 
 const waveshare4in2Horizontal = {
     height: 300,
@@ -132,7 +132,6 @@ const waveshare3in7HorizontalGray = {
         this.driver.init_4Gray();
     },
 };
-
 
 const devices = {
     // default waveshare4in2 kept for backwards compatibility with release 1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epaperjs",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "epaperjs",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "Simple e-Paper display on a Raspberry Pi using Javascript and HTML",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Added 3in7 pi shield waveshare epaper display.
The only weirdness is in c/EPD_3in7_node.cc, when initializing in 1gray mode I was required to init and clear 4gray content first; otherwise, a residual image will remain. 

While init() is slow with the 4gray_clear() involved, the 3in7 does have a nice 1gray update that is super fast. video here: [link](https://photos.app.goo.gl/Rs8sJvcuQ7pEJtma8)

tested with weather and ereader demos in all orientations in 1gray/4gray mode.