### PR TITLE
fix: 42 text displayed backwards on 2in7 display

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -213,9 +213,7 @@ const waveshare2in7Horizontal = {
     width: 264,
     driver: waveshare2in7Driver,
     displayPNG: async function (imgContents) {
-        const buffer = await image.convertPNGto1BitBW2in13V2Rotated(
-            imgContents
-        );
+        const buffer = await image.convertPNGto1BitBWRotated(imgContents);
         this.driver.display(buffer);
     },
     init: function () {
@@ -227,7 +225,7 @@ const waveshare2in7Vertical = {
     width: 176,
     driver: waveshare2in7Driver,
     displayPNG: async function (imgContents) {
-        const buffer = await image.convertPNGto1BitBW2in13V2(imgContents);
+        const buffer = await image.convertPNGto1BitBW(imgContents);
         this.driver.display(buffer);
     },
     init: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epaperjs",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "epaperjs",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Simple e-Paper display on a Raspberry Pi using Javascript and HTML",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
To test this, do the following:
1. Clone this PR
2. In the root directory, run `npm install`
3. Edit `examples/weather-station/weather.js` to look as follows:
```
const { init, devices } = require('epaperjs');

init(devices.waveshare2in7);
```
4. In the `weather-station` directory run `npm install`
5. In the `weather-station` directory run `npm run start`
6. You should see the weather station example displayed correctly.
7. Please repeat for the vertical orientation
