### PR TITLE
Update refs from rpi-cli -> ejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For available devices types, see [supported hardware](#supported-hardware). The 
 **Display**: display a single rendition of a URL
 
 ```
-rpi-cli display [options] <deviceType> <url>
+ejs display [options] <deviceType> <url>
 ```
 
 | Option               | Description                                                                                            | Allowed Values        |
@@ -54,7 +54,7 @@ rpi-cli display [options] <deviceType> <url>
 **Refresh**: continuously update and display the URL
 
 ```
-rpi-cli refresh [options] <deviceType> <url>
+ejs refresh [options] <deviceType> <url>
 ```
 
 | Option               | Description                                                                                            | Allowed Values                   |
@@ -73,7 +73,7 @@ rpi-cli refresh [options] <deviceType> <url>
 **Clear**: clear the display
 
 ```
-rpi-cli clear [options] <deviceType>
+ejs clear [options] <deviceType>
 ```
 
 | Option      | Description                               | Allowed Values |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @epaperjs/rpi-cli
+# @epaperjs/cli
 
 ## 2.1.1
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ For available devices types, see [supported hardware](#supported-hardware). The 
 **Display**: display a single rendition of a URL
 
 ```
-rpi-cli display [options] <deviceType> <url>
+ejs display [options] <deviceType> <url>
 ```
 
 | Option               | Description                                                                                            | Allowed Values        |
@@ -39,7 +39,7 @@ rpi-cli display [options] <deviceType> <url>
 **Refresh**: continuously update and display the URL
 
 ```
-rpi-cli refresh [options] <deviceType> <url>
+ejs refresh [options] <deviceType> <url>
 ```
 
 | Option               | Description                                                                                            | Allowed Values                   |
@@ -58,7 +58,7 @@ rpi-cli refresh [options] <deviceType> <url>
 **Clear**: clear the display
 
 ```
-rpi-cli clear [options] <deviceType>
+ejs clear [options] <deviceType>
 ```
 
 | Option      | Description                               | Allowed Values |


### PR DESCRIPTION
Updating some references in Readme/Changlog from (I think) previously named `rpi-cli` to `ejs`. 